### PR TITLE
Fix failing on zombie processes

### DIFF
--- a/app/lib/base/system.py
+++ b/app/lib/base/system.py
@@ -26,12 +26,17 @@ class SystemManager:
     def process_list(self):
         processes = []
         for proc in psutil.process_iter():
-            processes.append(
-                {
-                    'id': proc.pid,
-                    'cmdline': proc.cmdline()
-                }
-            )
+            try:
+                processes.append(
+                    {
+                        'id': proc.pid,
+                        'cmdline': proc.cmdline()
+                    }
+                )
+            except psutil.NoSuchProcess:
+                # Ignore zombie processes
+                pass
+
         return processes
 
     def process_kill(self, pid):


### PR DESCRIPTION
At some point psutil merged https://github.com/giampaolo/psutil/pull/2288 and now `proc.cmdline()` will fail if there are zombies in process list. This PR fixes that.